### PR TITLE
Handle validating responses with no presence on swagger schema

### DIFF
--- a/src/Test/Exception/UnknownResponseCodeException.php
+++ b/src/Test/Exception/UnknownResponseCodeException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace WakeOnWeb\Component\Swagger\Test\Exception;
+
+/**
+ * @author Quentin Schuler <q.schuler@wakeonweb.com>
+ */
+class UnknownResponseCodeException extends SwaggerValidatorException
+{
+    /**
+     * @param int $code
+     *
+     * @return SwaggerValidatorException
+     */
+    public static function fromUnknownStatusCode($code)
+    {
+        return new self(sprintf(
+            'The response status code is unknown to the schema. Got %d.',
+            $code
+        ));
+    }
+}

--- a/src/Test/SwaggerValidator.php
+++ b/src/Test/SwaggerValidator.php
@@ -10,6 +10,7 @@ use WakeOnWeb\Component\Swagger\Specification\Swagger;
 use WakeOnWeb\Component\Swagger\Test\Exception\ContentTypeException;
 use WakeOnWeb\Component\Swagger\Test\Exception\StatusCodeException;
 use WakeOnWeb\Component\Swagger\Test\Exception\SwaggerValidatorException;
+use WakeOnWeb\Component\Swagger\Test\Exception\UnknownResponseCodeException;
 use WakeOnWeb\Component\Swagger\Test\Exception\UnknownPathException;
 
 /**
@@ -77,6 +78,11 @@ class SwaggerValidator
             ->getResponses()
             ->getResponseFor($code)
         ;
+
+        // In this case, the response given to us is not on the schema
+        if ($response === null) {
+            throw UnknownResponseCodeException::fromUnknownStatusCode($code);
+        }
 
         if ($actual->getStatusCode() !== $code) {
             throw StatusCodeException::fromInvalidStatusCode($code, $actual->getStatusCode());

--- a/tests/Test/SwaggerValidatorTest.php
+++ b/tests/Test/SwaggerValidatorTest.php
@@ -90,6 +90,45 @@ JSON;
 
     /**
      * @test
+     * @expectedException \WakeOnWeb\Component\Swagger\Test\Exception\UnknownResponseCodeException
+     */
+    public function testValidateResponseForThrowsAnExceptionWhenTheStatusCodeIsNotOnTheSchema()
+    {
+        $swagger = <<<JSON
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "test",
+        "version": "1.0"
+    },
+    "produces": [
+        "application/json"
+    ],
+    "paths": {
+        "/tests": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Get the list of all the tests cases."
+                    }
+                }
+            }
+        }
+    }
+}
+JSON;
+
+        $code = 400;
+        $prophecy = $this->prophesize(ResponseInterface::class);
+        $prophecy->getStatusCode()->willReturn($code);
+        $prophecy->getHeader('Content-Type')->willReturn(['application/json']);
+
+        $validator = new SwaggerValidator($this->buildSwagger($swagger));
+        $validator->validateResponseFor($prophecy->reveal(), PathItem::METHOD_GET, '/tests', $code);
+    }
+
+    /**
+     * @test
      * @expectedException \WakeOnWeb\Component\Swagger\Test\Exception\ContentTypeException
      */
     public function testValidateResponseForThrowsAnExceptionWhenTheContentTypeIsInvalid()


### PR DESCRIPTION
Throw a validator exception when validating a response, and the givenstatus code is not on the swagger schema.