### PR TITLE
 Fix parseTag with externalDocs

### DIFF
--- a/src/SwaggerFactory.php
+++ b/src/SwaggerFactory.php
@@ -911,7 +911,7 @@ class SwaggerFactory
         $externalDocs = $this->get($spec, 'externalDocs');
 
         if ($externalDocs !== null) {
-            $externalDocs = $this->parseExternalDocumentation($spec, $chains);
+            $externalDocs = $this->parseExternalDocumentation($externalDocs, $chains);
         }
 
         return new Tag($name, $description, $externalDocs);


### PR DESCRIPTION
Use the $externalDocs instead of $spec as parameter for parseExternalDocumentation when externalDocs is given.

If you want to reproduce the error, try to build from the popular petstore example: http://petstore.swagger.io/v2/swagger.json